### PR TITLE
mark modemmanager release candidates are devel

### DIFF
--- a/rules.d/900.version-fixes.yaml
+++ b/rules.d/900.version-fixes.yaml
@@ -468,6 +468,7 @@
 - { name: mkgmap,                      verpat: "0\\.0\\.0svn([0-9]{4,})",                  setver: "r$1" }
 - { name: mkgmap,                      verpat: "[0-9]{4,}",                                setver: "r$0" }
 - { name: mkgmap-splitter,             verpat: "0\\.0\\.0svn([0-9]{3,})",                  setver: "r$1" }
+- { name: modem-manager,               verpat: "[0-9]*.[0-9]*.99[0-9]+",                   devel: true }
 - { name: moc,                         ver: ["2.6","2.6.0"],         family: [sisyphus,fedora], ignore: true } # 2.6alpha3
 - { name: moc,                         verpat: "2\\.6\\.0r.*",                             ignore: true }
 - { name: moc,                         verpat: "(2\\.6)\\.0(a.*)",                         setver: "$1$2" } # there's no third numeric component for alpha


### PR DESCRIPTION
Announcement of release candidate version 1.7.990: https://lists.freedesktop.org/archives/modemmanager-devel/2018-January/006157.html